### PR TITLE
Improve cell animations and selection behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,6 +61,22 @@ function manageClock() {
     });
 }
 
+function addFallAnimation(cell) {
+    cell.classList.add('fall');
+    const handler = () => {
+        cell.classList.remove('fall');
+        cell.removeEventListener('animationend', handler);
+    };
+    cell.addEventListener('animationend', handler);
+}
+
+function flashGridBackground() {
+    gameContainer.classList.add('flash-bg');
+    setTimeout(() => {
+        gameContainer.classList.remove('flash-bg');
+    }, 1000);
+}
+
 function createGrid(rows, cols) {
     gameContainer.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
     gameContainer.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
@@ -244,6 +260,7 @@ function removePulsatingCells(matches) {
                     const newRow = row + emptySpaceCount;
                     board[newRow][col] = board[row][col];
                     cellReferences[newRow][col].className = `cell ${board[newRow][col]}`;
+                    addFallAnimation(cellReferences[newRow][col]);
                     board[row][col] = null;
                     cellReferences[row][col].className = 'cell';
                 }
@@ -253,9 +270,12 @@ function removePulsatingCells(matches) {
                 const newColor = COLORS[Math.floor(Math.random() * COLORS.length)];
                 board[row][col] = newColor;
                 cellReferences[row][col].className = `cell ${newColor}`;
+                addFallAnimation(cellReferences[row][col]);
                 cellCounts[newColor]++;
             }
         }
+
+        flashGridBackground();
 
         newMatches = checkNewMatches();
 

--- a/styles2.css
+++ b/styles2.css
@@ -30,7 +30,7 @@ body {
     background-color: #ddd;
     border: 1px solid #999;
     cursor: pointer;
-    transition: background-color 0.3s;
+    transition: background-color 0.3s, transform 0.2s;
     position: relative;
 }
 
@@ -40,6 +40,8 @@ body {
 
 .cell.selected {
     border: 3px solid white;
+    transform: scale(1.2);
+    z-index: 1;
 }
 
 .cell.verde {
@@ -304,6 +306,32 @@ label {
         color: #FF9800;
         text-shadow: 0 0 5px #FF9800;
     }
+}
+
+@keyframes fall {
+    from {
+        top: -50px;
+    }
+    to {
+        top: 0;
+    }
+}
+
+.fall {
+    animation: fall 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+@keyframes gridFlash {
+    0%, 100% {
+        background-color: #333;
+    }
+    50% {
+        background-color: #ffffff;
+    }
+}
+
+.flash-bg {
+    animation: gridFlash 0.2s linear 5;
 }
 
 #game-over-overlay {


### PR DESCRIPTION
## Summary
- enlarge only selected cell with smooth transform
- animate cells falling into place and flash the grid background
- add helper functions in JS for fall animations and grid flashes

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685047ffde44832dae5255d18192736c