### PR TITLE
Fix color counter styling

### DIFF
--- a/styles2.css
+++ b/styles2.css
@@ -307,6 +307,7 @@ label {
     align-items: center;
     gap: 4px;
     background-color: transparent !important;
+    background-image: none !important;
     border: none;
     font-size: 14px;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- prevent cell-type styles from applying to color count boxes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c91125b0832daa369f0783fdcf09