### PR TITLE
Prevent initial skulls in bottom row

### DIFF
--- a/script.js
+++ b/script.js
@@ -131,9 +131,12 @@ function fillGrid() {
     createGrid(rows, cols);
 
     document.querySelectorAll('.cell').forEach(cell => {
-        const randomColor = COLORS[Math.floor(Math.random() * COLORS.length)];
-        const row = cell.dataset.row;
-        const col = cell.dataset.col;
+        const row = parseInt(cell.dataset.row);
+        const col = parseInt(cell.dataset.col);
+        const availableColors = row === rows - 1
+            ? COLORS.filter(color => color !== 'calavera')
+            : COLORS;
+        const randomColor = availableColors[Math.floor(Math.random() * availableColors.length)];
         board[row][col] = randomColor;
         cell.className = `cell ${randomColor}`;
         cellCounts[randomColor]++;


### PR DESCRIPTION
## Summary
- ensure bottom row never spawns the `calavera` pattern when filling the grid

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6876cae14820832d98f4eb00fa62b6ab