### PR TITLE
Implement Skull Risk metric

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
             </div>
 
             <div class="separator-line"></div>
-            <div id="score-display">Puntaje: <span id="current-score">0000-0000-0000-0000</span></div>
+            <div id="rrc-display">RRC: <span id="skull-risk">0%</span></div>
             <div id="average-cells-removed">Promedio de Celdas Removidas: <span id="current-average">0.00</span></div>
             <div class="separator-line"></div>
             <div id="cells-removed-counter">Celdas Eliminadas: <span id="cells-removed">0</span></div>

--- a/styles2.css
+++ b/styles2.css
@@ -272,11 +272,18 @@ label {
 }
 */
 
-#score-display, #average-cells-removed, #cells-removed-counter, #cells-removed-round {
+#rrc-display, #average-cells-removed, #cells-removed-counter, #cells-removed-round {
     font-size: 16px;
     font-weight: bold;
     text-align: center;
     color: #333;
+}
+
+#skull-risk {
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    color: red;
 }
 
 #version-text {
@@ -406,17 +413,16 @@ label {
     }
 }
 
-.blink-score {
-    animation: blinkScore 2s ease-in-out;
+.blink-risk {
+    animation: blinkRisk 1s ease-in-out;
 }
 
-@keyframes blinkScore {
+@keyframes blinkRisk {
     0%, 100% {
-        color: #333;
+        color: red;
     }
     50% {
-        color: #4CAF50;
-        text-shadow: 0 0 10px #4CAF50;
+        color: darkred;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace score display with RRC (skull risk) indicator
- compute skull risk based on skull proximity
- update grid filling, cascade processing and reset logic to use skull risk
- remove all score calculation logic
- style RRC indicator in red Arial font with blink effect for high risk

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6877f1bf9140832daceada68b79f792d