### PR TITLE
Fix RRC risk update after cascades

### DIFF
--- a/script.js
+++ b/script.js
@@ -368,6 +368,8 @@ async function processMatchedCells(matches) {
 
     await wait((maxDelay + FALL_DURATION) * 1000);
 
+    updateSkullRiskDisplay();
+
     newMatches = checkNewMatches();
 
     if (newMatches.size > 0) {
@@ -407,7 +409,6 @@ async function processMatchedCells(matches) {
         if (skullRiskHistory.length > 5) {
             skullRiskHistory.shift();
         }
-        updateSkullRiskDisplay();
     }
     updateColorSamples();
     checkForCalavera();


### PR DESCRIPTION
## Summary
- refresh the RRC display after each cascade

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6877f802cfa4832d96204fa2437e6805