### PR TITLE
Ensure skull matches are detected during cascades

### DIFF
--- a/script.js
+++ b/script.js
@@ -763,8 +763,7 @@ async function processMatchedCells(matches) {
 }
 
 function checkNewMatches() {
-    const skipValues = activeConfig?.VALOR_PELIGROSO ? [activeConfig.VALOR_PELIGROSO] : [];
-    return findMatches(board, { skipValues });
+    return findMatches(board, { skipValues: [] });
 }
 
 


### PR DESCRIPTION
## Summary
- update checkNewMatches to include skulls when searching for match patterns
- ensure hazardous tiles are removed when they form part of cascades

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691229a3751c832db0e5c35cee9f9ef7)