### PR TITLE
Prevent processing state from dimming falling or matched cells

### DIFF
--- a/styles2.css
+++ b/styles2.css
@@ -126,6 +126,15 @@ body {
     opacity: 0.6;
 }
 
+/* Regla para asegurar que las celdas en el patrón no se atenúen */
+.cell.processing.matched {
+    opacity: 1 !important; /* Fuerza la opacidad completa (brillante) */
+}
+
+.cell.processing.falling {
+    opacity: 1 !important;
+}
+
 #controls-container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- mark falling cells with a dedicated class during the animation so they can opt out of processing opacity
- ensure matched and falling cells retain full opacity even while the board is locked for processing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136383f62c832db3c2f157ae69a762)