### PR TITLE
Add continue flow after skull game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,10 @@
                 <span id="game-over-reason"></span>
                 <span id="game-over-threshold"></span>
             </p>
-            <button id="restart-button" onclick="resetGame()">Reiniciar Juego</button>
+            <div id="game-over-buttons">
+                <button id="continue-button" onclick="continueGame()">Continuar</button>
+                <button id="restart-button" onclick="resetGame()">Reiniciar Juego</button>
+            </div>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -976,18 +976,78 @@ function showGameOver(reason) {
     const message = document.getElementById('game-over-message');
     const gameOverReason = document.getElementById('game-over-reason');
     const gameOverThreshold = document.getElementById('game-over-threshold');
+    const continueBtn = document.getElementById('continue-button');
 
     if (reason === 'Tiempo agotado') {
         gameOverReason.textContent = '¡Se acabó el tiempo!';
         gameOverThreshold.style.display = 'none';
+        if (continueBtn) continueBtn.style.display = 'none';
     } else if (reason) {
         gameOverReason.textContent = reason;
         gameOverThreshold.style.display = 'none';
+
+        if (reason.includes('Muerte') && continueBtn) {
+            continueBtn.style.display = 'inline-block';
+        } else if (continueBtn) {
+            continueBtn.style.display = 'none';
+        }
     }
 
     overlay.style.display = 'flex';
     setProcessingState(true); // Asegúrate de que esto está en true para evitar nuevas interacciones
 }
+
+function continueGame() {
+    const bottomRowIndex = board.length - 1;
+    const safeColors = CONFIG.VALORES_SEGUROS_FILA_0;
+
+    let replacedCount = 0;
+
+    for (let col = 0; col < cols; col++) {
+        if (board[bottomRowIndex][col] === 'calavera') {
+            let bestColor = null;
+            const shuffledColors = [...safeColors].sort(() => Math.random() - 0.5);
+
+            for (let color of shuffledColors) {
+                if (!createsMatchAtPosition(bottomRowIndex, col, color)) {
+                    bestColor = color;
+                    break;
+                }
+            }
+
+            if (!bestColor) {
+                bestColor = shuffledColors[0];
+            }
+
+            board[bottomRowIndex][col] = bestColor;
+
+            const cell = cellReferences[bottomRowIndex][col];
+            if (cell) {
+                cell.className = `cell ${bestColor}`;
+                cell.style.animation = 'none';
+                cell.offsetHeight;
+                cell.style.animation = 'blink-highlight 0.5s ease-in-out';
+            }
+
+            replacedCount++;
+        }
+    }
+
+    if (replacedCount > 0) {
+        console.log(`Juego continuado: ${replacedCount} calaveras reemplazadas.`);
+
+        recalcularContadoresDesdeBoard();
+        updateColorSamples();
+
+        document.getElementById('game-over-overlay').style.display = 'none';
+
+        setProcessingState(false);
+
+        allowCalaveraGameOver = true;
+    }
+}
+
+window.continueGame = continueGame;
 
 function updateCellsRemovedDisplay() {
     // Mostrar el total de celdas eliminadas

--- a/styles2.css
+++ b/styles2.css
@@ -430,6 +430,27 @@ label {
     color: #333;
 }
 
+#game-over-buttons {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}
+
+#continue-button {
+    display: none;
+    background-color: #2196F3;
+    color: white;
+    padding: 15px 30px;
+    font-size: 18px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+#continue-button:hover {
+    background-color: #0b7dda;
+}
+
 #restart-button {
     background-color: #4CAF50;
     color: white;


### PR DESCRIPTION
## Summary
- add a continue action to the game over overlay for skull-related defeats
- style the new continue control and button group alongside restart
- implement logic to replace bottom-row skulls safely and resume play without resetting progress

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db003e724832d85cfad1db5d48f3e)